### PR TITLE
Add copy buttons for verses

### DIFF
--- a/app.js
+++ b/app.js
@@ -192,7 +192,7 @@
       const txtDiv = document.createElement("div");
       txtDiv.className = "verset";
       txtDiv.textContent = text;
-      txtDiv.dataset.clip = `${reference} ${text}`;
+      txtDiv.dataset.clip = `${reference}\n${text}`;
       bloc.appendChild(txtDiv);
       const copyBtn = document.createElement("button");
       copyBtn.textContent = "Copiar";
@@ -218,7 +218,7 @@
       copyAllBtn.onclick = () => {
         const all = Array.from(versets)
           .map((v) => v.dataset.clip)
-          .join("\n");
+          .join("\n\n");
         navigator.clipboard.writeText(all);
         showToast("Copiat tot");
       };

--- a/app.js
+++ b/app.js
@@ -5,6 +5,21 @@
   const loading = document.getElementById("carregant");
   const outDiv = document.getElementById("resultats");
   const copyAllBtn = document.getElementById("copiarTots");
+  function showToast(msg) {
+    const t = document.getElementById("toast");
+    if (!t) return;
+    t.textContent = msg;
+    t.style.display = "block";
+    requestAnimationFrame(() => {
+      t.style.opacity = "1";
+    });
+    setTimeout(() => {
+      t.style.opacity = "0";
+      setTimeout(() => {
+        t.style.display = "none";
+      }, 300);
+    }, 1000);
+  }
 
   // ────────────────────────────────────────
   // Utilitats
@@ -166,7 +181,8 @@
       bloc.className = "bloc";
       const tit = document.createElement("div");
       tit.className = "titol";
-      tit.textContent = `${bookRaw.toUpperCase()} ${cap}:${versSpec}`;
+      const reference = `${bookRaw.toUpperCase()} ${cap}:${versSpec}`;
+      tit.textContent = reference;
       bloc.appendChild(tit);
       const text = versesNodes
         .map((v) =>
@@ -176,11 +192,13 @@
       const txtDiv = document.createElement("div");
       txtDiv.className = "verset";
       txtDiv.textContent = text;
+      txtDiv.dataset.clip = `${reference} ${text}`;
       bloc.appendChild(txtDiv);
       const copyBtn = document.createElement("button");
       copyBtn.textContent = "Copiar";
       copyBtn.addEventListener("click", () => {
-        navigator.clipboard.writeText(text);
+        navigator.clipboard.writeText(txtDiv.dataset.clip);
+        showToast("Copiat");
       });
       bloc.appendChild(copyBtn);
       outDiv.appendChild(bloc);
@@ -199,9 +217,10 @@
       copyAllBtn.style.display = "";
       copyAllBtn.onclick = () => {
         const all = Array.from(versets)
-          .map((v) => v.textContent)
+          .map((v) => v.dataset.clip)
           .join("\n");
         navigator.clipboard.writeText(all);
+        showToast("Copiat tot");
       };
     }
   }

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@
   const btn = document.getElementById("cerca");
   const loading = document.getElementById("carregant");
   const outDiv = document.getElementById("resultats");
+  const copyAllBtn = document.getElementById("copiarTots");
 
   // ────────────────────────────────────────
   // Utilitats
@@ -92,6 +93,7 @@
 
   function process() {
     outDiv.innerHTML = "";
+    copyAllBtn.style.display = "none";
     const raw = inputEl.value.trim();
     if (!raw) return;
 
@@ -171,7 +173,16 @@
           v.getElementsByTagName("texto_versiculo")[0].textContent.trim()
         )
         .join(" ");
-      bloc.appendChild(document.createTextNode(text));
+      const txtDiv = document.createElement("div");
+      txtDiv.className = "verset";
+      txtDiv.textContent = text;
+      bloc.appendChild(txtDiv);
+      const copyBtn = document.createElement("button");
+      copyBtn.textContent = "Copiar";
+      copyBtn.addEventListener("click", () => {
+        navigator.clipboard.writeText(text);
+      });
+      bloc.appendChild(copyBtn);
       outDiv.appendChild(bloc);
     });
 
@@ -182,5 +193,16 @@
       d.textContent = er;
       outDiv.appendChild(d);
     });
+
+    const versets = outDiv.getElementsByClassName("verset");
+    if (versets.length) {
+      copyAllBtn.style.display = "";
+      copyAllBtn.onclick = () => {
+        const all = Array.from(versets)
+          .map((v) => v.textContent)
+          .join("\n");
+        navigator.clipboard.writeText(all);
+      };
+    }
   }
 })();

--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
         <button id="cercaParaula">Cerca paraules</button>
         <button id="netejar">Netejar</button>
     </div>
+    <div class="copy-row">
+        <button id="copiarTots" style="display:none">Copiar tots</button>
+    </div>
     <div id="carregant" style="display:none; margin-top:1rem;">Carregant Bíblia…</div>
     <div id="resultats"></div>
 

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
     </div>
     <div id="carregant" style="display:none; margin-top:1rem;">Carregant Bíblia…</div>
     <div id="resultats"></div>
+    <div id="toast" class="toast" style="display:none"></div>
 
     <!-- ───────────── Àlies editables en JSON ───────────── -->
     <script id="dicctionaryData" type="application/json">

--- a/style.css
+++ b/style.css
@@ -123,4 +123,17 @@ summary {
   margin-bottom: 0.5rem;
   display: block;
 }
+
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.3s;
+  pointer-events: none;
+}
   

--- a/style.css
+++ b/style.css
@@ -113,4 +113,14 @@ summary {
   font-weight: bold;
   margin-bottom: 0.25rem;
 }
+
+.copy-row {
+  margin-top: 0.5rem;
+  text-align: right;
+}
+
+.verset {
+  margin-bottom: 0.5rem;
+  display: block;
+}
   

--- a/word-search.js
+++ b/word-search.js
@@ -12,6 +12,19 @@
   const loading    = document.getElementById('carregant');
   const outDiv     = document.getElementById('resultats');
   const copyAllBtn = document.getElementById('copiarTots');
+  function showToast(msg) {
+    const t = document.getElementById('toast');
+    if (!t) return;
+    t.textContent = msg;
+    t.style.display = 'block';
+    requestAnimationFrame(() => {
+      t.style.opacity = '1';
+    });
+    setTimeout(() => {
+      t.style.opacity = '0';
+      setTimeout(() => { t.style.display = 'none'; }, 300);
+    }, 1000);
+  }
 
   function updateUI() {
     if (modeSel.value === 'words') {
@@ -147,17 +160,20 @@
       const tit = document.createElement('div');
       tit.className = 'titol';
       const range = g.start === g.end ? g.start : `${g.start}-${g.end}`;
-      tit.textContent = `${g.book.toUpperCase()} ${g.cap}:${range}`;
+      const reference = `${g.book.toUpperCase()} ${g.cap}:${range}`;
+      tit.textContent = reference;
       bloc.appendChild(tit);
       const text = g.texts.join(' ');
       const txtDiv = document.createElement('div');
       txtDiv.className = 'verset';
       txtDiv.textContent = text;
+      txtDiv.dataset.clip = `${reference} ${text}`;
       bloc.appendChild(txtDiv);
       const copyBtn = document.createElement('button');
       copyBtn.textContent = 'Copiar';
       copyBtn.addEventListener('click', () => {
-        navigator.clipboard.writeText(text);
+        navigator.clipboard.writeText(txtDiv.dataset.clip);
+        showToast('Copiat');
       });
       bloc.appendChild(copyBtn);
       outDiv.appendChild(bloc);
@@ -168,9 +184,10 @@
       copyAllBtn.style.display = '';
       copyAllBtn.onclick = () => {
         const all = Array.from(versets)
-          .map(v => v.textContent)
+          .map(v => v.dataset.clip)
           .join('\n');
         navigator.clipboard.writeText(all);
+        showToast('Copiat tot');
       };
     }
   }

--- a/word-search.js
+++ b/word-search.js
@@ -11,6 +11,7 @@
   const clearBtn   = document.getElementById('netejar');
   const loading    = document.getElementById('carregant');
   const outDiv     = document.getElementById('resultats');
+  const copyAllBtn = document.getElementById('copiarTots');
 
   function updateUI() {
     if (modeSel.value === 'words') {
@@ -92,10 +93,12 @@
     wordInput.value = '';
     exactChk.checked = false;
     outDiv.innerHTML = '';
+    copyAllBtn.style.display = 'none';
   });
 
   function search() {
     outDiv.innerHTML = '';
+    copyAllBtn.style.display = 'none';
     const raw = wordInput.value.trim();
     if (!raw) return;
 
@@ -146,8 +149,29 @@
       const range = g.start === g.end ? g.start : `${g.start}-${g.end}`;
       tit.textContent = `${g.book.toUpperCase()} ${g.cap}:${range}`;
       bloc.appendChild(tit);
-      bloc.appendChild(document.createTextNode(g.texts.join(' ')));
+      const text = g.texts.join(' ');
+      const txtDiv = document.createElement('div');
+      txtDiv.className = 'verset';
+      txtDiv.textContent = text;
+      bloc.appendChild(txtDiv);
+      const copyBtn = document.createElement('button');
+      copyBtn.textContent = 'Copiar';
+      copyBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(text);
+      });
+      bloc.appendChild(copyBtn);
       outDiv.appendChild(bloc);
     });
+
+    const versets = outDiv.getElementsByClassName('verset');
+    if (versets.length) {
+      copyAllBtn.style.display = '';
+      copyAllBtn.onclick = () => {
+        const all = Array.from(versets)
+          .map(v => v.textContent)
+          .join('\n');
+        navigator.clipboard.writeText(all);
+      };
+    }
   }
 })();

--- a/word-search.js
+++ b/word-search.js
@@ -167,7 +167,7 @@
       const txtDiv = document.createElement('div');
       txtDiv.className = 'verset';
       txtDiv.textContent = text;
-      txtDiv.dataset.clip = `${reference} ${text}`;
+      txtDiv.dataset.clip = `${reference}\n${text}`;
       bloc.appendChild(txtDiv);
       const copyBtn = document.createElement('button');
       copyBtn.textContent = 'Copiar';
@@ -185,7 +185,7 @@
       copyAllBtn.onclick = () => {
         const all = Array.from(versets)
           .map(v => v.dataset.clip)
-          .join('\n');
+          .join('\n\n');
         navigator.clipboard.writeText(all);
         showToast('Copiat tot');
       };


### PR DESCRIPTION
## Summary
- add `Copiar tots` button to top of results
- style copy row and verse container
- allow copying individual verses
- enable copy-all functionality for reference and word searches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68726bcfa8288330bf52bad8a43cb916